### PR TITLE
Use '/' instead of path.sep for Windows. Close #13

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,16 +54,16 @@ function packageFilter(pkg, path, relativePath) {
 function findMeteorRoot(start) {
   start = start || module.parent.filename
   if (typeof start === 'string') {
-    if (start[start.length-1] !== path.sep) {
-      start+=path.sep
+    if (start[start.length-1] !== '/') {
+      start += '/'
     }
-    start = start.split(path.sep)
+    start = start.split('/')
   }
   if(!start.length) {
     throw new Error('.meteor not found in path')
   }
   start.pop()
-  var dir = start.join(path.sep)
+  var dir = start.join('/')
   try {
     fs.statSync(path.join(dir, '.meteor'))
     return dir


### PR DESCRIPTION
This PR makes this project pass all the tests on Windows to fix #13.

before:

```
  paths
    √ handles base path relative to CWD
    1) handles root (/) paths relative to CWD
    2) should not resolve a client file in a server file
    3) should not resolve a client file in a non-client file
    4) should not resolve a file ending in client in a non-client file
    5) should not resolve a server file in a client file
    6) should not resolve a server file in a non-server file
    7) should not resolve a file ending in server in a non-server file
    √ should resolve a file ending in server in a non-server file if it comes from a node module
    8) should resolve a custom Meteor package if it is in the packages file
    9) should not resolve a custom Meteor package if it is not in the packages file
    10) should resolve a built-in Meteor package if it is in the versions file
    11) should not resolve a built-in Meteor package if it is not in the versions file


  2 passing (89ms)
  11 failing
```

after:

```
  paths
    √ handles base path relative to CWD
    √ handles root (/) paths relative to CWD
    √ should not resolve a client file in a server file
    √ should not resolve a client file in a non-client file
    √ should not resolve a file ending in client in a non-client file
    √ should not resolve a server file in a client file
    √ should not resolve a server file in a non-server file
    √ should not resolve a file ending in server in a non-server file
    √ should resolve a file ending in server in a non-server file if it comes from a node module
    √ should resolve a custom Meteor package if it is in the packages file
    √ should not resolve a custom Meteor package if it is not in the packages file
    √ should resolve a built-in Meteor package if it is in the versions file
    √ should not resolve a built-in Meteor package if it is not in the versions file


  13 passing (47ms)
```
