### PR TITLE
Use slash instead of path.sep for regular expressions. Fix tests for Windows. Re-fix #13

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ exports.resolve = function (source, file, config) {
     meteorSource = path.resolve(meteorRoot, source.substr(1))
   }
 
-  var file_using_slash = file.split(path.sep).join('/')
-  if (!isNodeModuleImport(source) && (isClientInNonClient(source, file_using_slash) || isServerInNonServer(source, file_using_slash))) {
+  var fileUsingSlash = file.split(path.sep).join('/')
+  if (!isNodeModuleImport(source) && (isClientInNonClient(source, fileUsingSlash) || isServerInNonServer(source, fileUsingSlash))) {
     return { found: false }
   }
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ exports.resolve = function (source, file, config) {
     meteorSource = path.resolve(meteorRoot, source.substr(1))
   }
 
-  if (!isNodeModuleImport(source) && (isClientInNonClient(source, file) || isServerInNonServer(source, file))) {
+  var file_using_slash = file.split(path.sep).join('/')
+  if (!isNodeModuleImport(source) && (isClientInNonClient(source, file_using_slash) || isServerInNonServer(source, file_using_slash))) {
     return { found: false }
   }
 
@@ -54,16 +55,16 @@ function packageFilter(pkg, path, relativePath) {
 function findMeteorRoot(start) {
   start = start || module.parent.filename
   if (typeof start === 'string') {
-    if (start[start.length-1] !== '/') {
-      start += '/'
+    if (start[start.length-1] !== path.sep) {
+      start += path.sep
     }
-    start = start.split('/')
+    start = start.split(path.sep)
   }
   if(!start.length) {
     throw new Error('.meteor not found in path')
   }
   start.pop()
-  var dir = start.join('/')
+  var dir = start.join(path.sep)
   try {
     fs.statSync(path.join(dir, '.meteor'))
     return dir

--- a/test/paths.js
+++ b/test/paths.js
@@ -5,54 +5,54 @@ var meteorResolver = require('../index.js')
 
 describe('paths', function () {
   it('handles base path relative to CWD', function () {
-    expect(meteorResolver.resolve('./another-file', './test/imports/test-file.js'))
+    expect(meteorResolver.resolve('./another-file', './test/imports/test-file.js'.replace(/\//g, path.sep)))
       .to.have.property('path')
       .equal(path.resolve(__dirname, './imports/another-file.js'))
   })
 
   it('handles root (/) paths relative to CWD', function () {
-    expect(meteorResolver.resolve('/imports/another-file', './test/imports/test-file.js'))
+    expect(meteorResolver.resolve('/imports/another-file', './test/imports/test-file.js'.replace(/\//g, path.sep)))
       .to.have.property('path')
       .equal(path.resolve(__dirname, './imports/another-file.js'))
   })
 
   it('should not resolve a client file in a server file', function () {
-    expect(meteorResolver.resolve('/imports/client/client-test', './test/imports/server/server-test.js'))
+    expect(meteorResolver.resolve('/imports/client/client-test', './test/imports/server/server-test.js'.replace(/\//g, path.sep)))
       .to.deep.equal({found: false})
   })
 
   it('should not resolve a client file in a non-client file', function () {
-    expect(meteorResolver.resolve('/imports/client/client-test', './test/imports/package-test/plain-file.js'))
+    expect(meteorResolver.resolve('/imports/client/client-test', './test/imports/package-test/plain-file.js'.replace(/\//g, path.sep)))
       .to.deep.equal({found: false})
   })
 
   it('should not resolve a file ending in client in a non-client file', function () {
-    expect(meteorResolver.resolve('/imports/package-test/client', './test/imports/package-test/plain-file.js'))
+    expect(meteorResolver.resolve('/imports/package-test/client', './test/imports/package-test/plain-file.js'.replace(/\//g, path.sep)))
       .to.deep.equal({found: false})
   })
 
   it('should not resolve a server file in a client file', function () {
-    expect(meteorResolver.resolve('/imports/server/server-test', './test/imports/client/client-test.js'))
+    expect(meteorResolver.resolve('/imports/server/server-test', './test/imports/client/client-test.js'.replace(/\//g, path.sep)))
       .to.deep.equal({found: false})
   })
 
   it('should not resolve a server file in a non-server file', function () {
-    expect(meteorResolver.resolve('/imports/server/server-test', './test/imports/package-test/plain-file.js'))
+    expect(meteorResolver.resolve('/imports/server/server-test', './test/imports/package-test/plain-file.js'.replace(/\//g, path.sep)))
       .to.deep.equal({found: false})
   })
 
   it('should not resolve a file ending in server in a non-server file', function () {
-    expect(meteorResolver.resolve('/imports/package-test/server', './test/imports/package-test/plain-file.js'))
+    expect(meteorResolver.resolve('/imports/package-test/server', './test/imports/package-test/plain-file.js'.replace(/\//g, path.sep)))
       .to.deep.equal({found: false})
   })
 
   it(`should resolve a file ending in server in a non-server file if it comes from a node module`, function () {
-    expect(meteorResolver.resolve('react-dom/server', './test/imports/package-test/plain-file.js'))
+    expect(meteorResolver.resolve('react-dom/server', './test/imports/package-test/plain-file.js'.replace(/\//g, path.sep)))
       .to.have.property('found', true)
   })
 
   it('should resolve a custom Meteor package if it is in the packages file', function () {
-    expect(meteorResolver.resolve('meteor/test:package', './test/imports/client/client-test.js'))
+    expect(meteorResolver.resolve('meteor/test:package', './test/imports/client/client-test.js'.replace(/\//g, path.sep)))
       .to.deep.equal({
         found: true,
         path: null
@@ -60,12 +60,12 @@ describe('paths', function () {
   })
 
   it('should not resolve a custom Meteor package if it is not in the packages file', function () {
-    expect(meteorResolver.resolve('meteor/fake:package', './test/imports/client/client-test.js'))
+    expect(meteorResolver.resolve('meteor/fake:package', './test/imports/client/client-test.js'.replace(/\//g, path.sep)))
       .to.deep.equal({found: false})
   })
 
   it('should resolve a built-in Meteor package if it is in the versions file', function () {
-    expect(meteorResolver.resolve('meteor/meteor', './test/imports/client/client-test.js'))
+    expect(meteorResolver.resolve('meteor/meteor', './test/imports/client/client-test.js'.replace(/\//g, path.sep)))
       .to.deep.equal({
         found: true,
         path: null
@@ -73,7 +73,7 @@ describe('paths', function () {
   })
 
   it('should not resolve a built-in Meteor package if it is not in the versions file', function () {
-    expect(meteorResolver.resolve('meteor/email', './test/imports/client/client-test.js'))
+    expect(meteorResolver.resolve('meteor/email', './test/imports/client/client-test.js'.replace(/\//g, path.sep)))
       .to.deep.equal({found: false})
   })
 })

--- a/test/paths.js
+++ b/test/paths.js
@@ -3,56 +3,60 @@ var expect = require('chai').expect
 var path = require('path')
 var meteorResolver = require('../index.js')
 
+function replaceSlashWithPathSep(filePath) {
+  return filePath.replace(/\//g, path.sep);
+}
+
 describe('paths', function () {
   it('handles base path relative to CWD', function () {
-    expect(meteorResolver.resolve('./another-file', './test/imports/test-file.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('./another-file', replaceSlashWithPathSep('./test/imports/test-file.js')))
       .to.have.property('path')
       .equal(path.resolve(__dirname, './imports/another-file.js'))
   })
 
   it('handles root (/) paths relative to CWD', function () {
-    expect(meteorResolver.resolve('/imports/another-file', './test/imports/test-file.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('/imports/another-file', replaceSlashWithPathSep('./test/imports/test-file.js')))
       .to.have.property('path')
       .equal(path.resolve(__dirname, './imports/another-file.js'))
   })
 
   it('should not resolve a client file in a server file', function () {
-    expect(meteorResolver.resolve('/imports/client/client-test', './test/imports/server/server-test.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('/imports/client/client-test', replaceSlashWithPathSep('./test/imports/server/server-test.js')))
       .to.deep.equal({found: false})
   })
 
   it('should not resolve a client file in a non-client file', function () {
-    expect(meteorResolver.resolve('/imports/client/client-test', './test/imports/package-test/plain-file.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('/imports/client/client-test', replaceSlashWithPathSep('./test/imports/package-test/plain-file.js')))
       .to.deep.equal({found: false})
   })
 
   it('should not resolve a file ending in client in a non-client file', function () {
-    expect(meteorResolver.resolve('/imports/package-test/client', './test/imports/package-test/plain-file.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('/imports/package-test/client', replaceSlashWithPathSep('./test/imports/package-test/plain-file.js')))
       .to.deep.equal({found: false})
   })
 
   it('should not resolve a server file in a client file', function () {
-    expect(meteorResolver.resolve('/imports/server/server-test', './test/imports/client/client-test.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('/imports/server/server-test', replaceSlashWithPathSep('./test/imports/client/client-test.js')))
       .to.deep.equal({found: false})
   })
 
   it('should not resolve a server file in a non-server file', function () {
-    expect(meteorResolver.resolve('/imports/server/server-test', './test/imports/package-test/plain-file.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('/imports/server/server-test', replaceSlashWithPathSep('./test/imports/package-test/plain-file.js')))
       .to.deep.equal({found: false})
   })
 
   it('should not resolve a file ending in server in a non-server file', function () {
-    expect(meteorResolver.resolve('/imports/package-test/server', './test/imports/package-test/plain-file.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('/imports/package-test/server', replaceSlashWithPathSep('./test/imports/package-test/plain-file.js')))
       .to.deep.equal({found: false})
   })
 
   it(`should resolve a file ending in server in a non-server file if it comes from a node module`, function () {
-    expect(meteorResolver.resolve('react-dom/server', './test/imports/package-test/plain-file.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('react-dom/server', replaceSlashWithPathSep('./test/imports/package-test/plain-file.js')))
       .to.have.property('found', true)
   })
 
   it('should resolve a custom Meteor package if it is in the packages file', function () {
-    expect(meteorResolver.resolve('meteor/test:package', './test/imports/client/client-test.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('meteor/test:package', replaceSlashWithPathSep('./test/imports/client/client-test.js')))
       .to.deep.equal({
         found: true,
         path: null
@@ -60,12 +64,12 @@ describe('paths', function () {
   })
 
   it('should not resolve a custom Meteor package if it is not in the packages file', function () {
-    expect(meteorResolver.resolve('meteor/fake:package', './test/imports/client/client-test.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('meteor/fake:package', replaceSlashWithPathSep('./test/imports/client/client-test.js')))
       .to.deep.equal({found: false})
   })
 
   it('should resolve a built-in Meteor package if it is in the versions file', function () {
-    expect(meteorResolver.resolve('meteor/meteor', './test/imports/client/client-test.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('meteor/meteor', replaceSlashWithPathSep('./test/imports/client/client-test.js')))
       .to.deep.equal({
         found: true,
         path: null
@@ -73,7 +77,7 @@ describe('paths', function () {
   })
 
   it('should not resolve a built-in Meteor package if it is not in the versions file', function () {
-    expect(meteorResolver.resolve('meteor/email', './test/imports/client/client-test.js'.replace(/\//g, path.sep)))
+    expect(meteorResolver.resolve('meteor/email', replaceSlashWithPathSep('./test/imports/client/client-test.js')))
       .to.deep.equal({found: false})
   })
 })


### PR DESCRIPTION
- Revert #14 because my old fix was wrong.
- `clientRe` and `serverRe` expect that a path string includes `/` so my new fix replaces `path.sep` with `/`.
- Test cases use `/` and cause test failures on Windows so I replace `/` with `path.sep`.
