### PR TITLE
Partially disabled client/server checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ exports.resolve = function (source, file, config) {
   }
 
   var fileUsingSlash = file.split(path.sep).join('/')
-  if (!isNodeModuleImport(source) && (isClientInNonClient(source, fileUsingSlash) || isServerInNonServer(source, fileUsingSlash))) {
+  if (!isNodeModuleImport(source) && (isClientInServer(source, fileUsingSlash) || isServerInClient(source, fileUsingSlash))) {
     return { found: false }
   }
 
@@ -76,12 +76,12 @@ function isNodeModuleImport(source) {
   return !notNodeModuleRe.test(source)
 }
 
-function isClientInNonClient(source, file) {
-  return clientRe.test(source) && !clientRe.test(file)
+function isClientInServer(source, file) {
+  return serverRe.test(source) && clientRe.test(file)
 }
 
-function isServerInNonServer(source, file) {
-  return serverRe.test(source) && !serverRe.test(file)
+function isServerInClient(source, file) {
+  return clientRe.test(source) && serverRe.test(file)
 }
 
 function resolveMeteorPackage(source, meteorRoot) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-import-resolver-meteor",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Meteor import resolution plugin for eslint-plugin-import.",
   "main": "index.js",
   "scripts": {

--- a/test/paths.js
+++ b/test/paths.js
@@ -25,14 +25,9 @@ describe('paths', function () {
       .to.deep.equal({found: false})
   })
 
-  it('should not resolve a client file in a non-client file', function () {
+  it('should resolve a client file in a non-client file which is not inside a server folder', function () {
     expect(meteorResolver.resolve('/imports/client/client-test', replaceSlashWithPathSep('./test/imports/package-test/plain-file.js')))
-      .to.deep.equal({found: false})
-  })
-
-  it('should not resolve a file ending in client in a non-client file', function () {
-    expect(meteorResolver.resolve('/imports/package-test/client', replaceSlashWithPathSep('./test/imports/package-test/plain-file.js')))
-      .to.deep.equal({found: false})
+      .to.have.property('found', true)
   })
 
   it('should not resolve a server file in a client file', function () {
@@ -40,14 +35,9 @@ describe('paths', function () {
       .to.deep.equal({found: false})
   })
 
-  it('should not resolve a server file in a non-server file', function () {
+  it('should resolve a server file in a non-server file which is not inside a client folder', function () {
     expect(meteorResolver.resolve('/imports/server/server-test', replaceSlashWithPathSep('./test/imports/package-test/plain-file.js')))
-      .to.deep.equal({found: false})
-  })
-
-  it('should not resolve a file ending in server in a non-server file', function () {
-    expect(meteorResolver.resolve('/imports/package-test/server', replaceSlashWithPathSep('./test/imports/package-test/plain-file.js')))
-      .to.deep.equal({found: false})
+      .to.have.property('found', true)
   })
 
   it(`should resolve a file ending in server in a non-server file if it comes from a node module`, function () {


### PR DESCRIPTION
Disabled checks that prevent user from importing a client file from non client file, and a server file from non server files.
However the new changes will raise error is user tries to import a server file from client and vice versa.

Also in the test I removed the following cases:

1. should not resolve a file ending in client in a non-client file
2. should not resolve a file ending in server in a non-server file

I didn't get the necessity of these test cases. 
  