### PR TITLE
Add ability to define custom meteorDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,16 +10,17 @@ var serverRe = /\/server(\/|$)/
 exports.interfaceVersion = 2
 
 exports.resolve = function (source, file, config) {
+  const meteorDir = config && config.meteorDir;
   if (resolve.isCore(source)) return { found: true, path: null }
 
   if (source.startsWith('meteor/')) {
-    var meteorRoot = findMeteorRoot(file)
+    var meteorRoot = findMeteorRoot(file, meteorDir)
     return resolveMeteorPackage(source, meteorRoot)
   }
 
   var meteorSource = source
   if (source.startsWith('/')) {
-    var meteorRoot = findMeteorRoot(file)
+    var meteorRoot = findMeteorRoot(file, meteorDir)
     meteorSource = path.resolve(meteorRoot, source.substr(1))
   }
 
@@ -52,8 +53,9 @@ function packageFilter(pkg, path, relativePath) {
   return pkg
 }
 
-function findMeteorRoot(start) {
+function findMeteorRoot(start, meteorDir) {
   start = start || module.parent.filename
+  meteorDir = meteorDir || '';
   if (typeof start === 'string') {
     if (start[start.length-1] !== path.sep) {
       start += path.sep
@@ -65,11 +67,12 @@ function findMeteorRoot(start) {
   }
   start.pop()
   var dir = start.join(path.sep)
+
   try {
-    fs.statSync(path.join(dir, '.meteor'))
-    return dir
+    fs.statSync(path.join(dir, meteorDir, '.meteor'))
+    return path.join(dir, meteorDir)
   } catch (e) {}
-  return findMeteorRoot(start)
+  return findMeteorRoot(start, meteorDir)
 }
 
 function isNodeModuleImport(source) {

--- a/test/custom/.meteor/versions
+++ b/test/custom/.meteor/versions
@@ -1,0 +1,1 @@
+tracker

--- a/test/paths.js
+++ b/test/paths.js
@@ -70,4 +70,10 @@ describe('paths', function () {
     expect(meteorResolver.resolve('meteor/email', replaceSlashWithPathSep('./test/imports/client/client-test.js')))
       .to.deep.equal({found: false})
   })
+
+  it('should resolve meteor packages in a custom meteor direcotry', function() {
+    expect(meteorResolver.resolve('meteor/tracker', replaceSlashWithPathSep('./test/imports/client/client-test.js'), {
+      meteorDir: 'custom'
+    })).to.deep.equal({ found: true, path: null })
+  })
 })


### PR DESCRIPTION
This should resolve https://github.com/clayne11/eslint-import-resolver-meteor/issues/9.

I added the ability to a property `meteorDir` to the resolver settings like this:

```yaml
settings:
  import/resolver:
    meteor:
      # directory in which the .meteor folder lies
      meteorDir: app
```

It basically goes down the directory tree (like it did before) and tries to find the `.meteor` directory in the given `meteorDir` directory.

It is, however, obviously exclusive (just one `.meteor` dir can be defined).

Looking forward to hearing your opinion on it :)

EDIT: if you approve of this change I'll happily amend the Readme (and also fix the nasty typo in the tests 😩 )