### PR TITLE
Resolve absolute file paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ exports.resolve = function (source, file, config) {
   var meteorSource = source
   if (source.startsWith('/')) {
     var meteorRoot = findMeteorRoot(file, meteorDir)
-    meteorSource = path.resolve(meteorRoot, source.substr(1))
+    if (!source.startsWith(meteorRoot)) meteorSource = path.resolve(meteorRoot, source.substr(1))
   }
 
   var fileUsingSlash = file.split(path.sep).join('/')


### PR DESCRIPTION
Currently, absolute paths like `/Users/work/dev/index.js` are mistaken as Meteor `/` imports.
This breaks the `import/no-unused-modules` rules in eslint.